### PR TITLE
Fix duplicate section IDs

### DIFF
--- a/src/Components/MyStack.tsx
+++ b/src/Components/MyStack.tsx
@@ -122,7 +122,7 @@ export default function MyStack({ selectedLanguage }: ProjectsHomeProps) {
 
     return (
         <div
-            id="experience"
+            id="stack"
             className="flex flex-col items-center justify-center w-full h-auto p-6 md:p-12 space-y-4 font-halcyon text-white bg-transparent rounded-lg border-t-2 border-[#FFFFE3]"
         >
 

--- a/src/Components/ProjectsHome.tsx
+++ b/src/Components/ProjectsHome.tsx
@@ -18,7 +18,7 @@ export default function ProjectsHome({ selectedLanguage }: ProjectsHomeProps) {
     const projects: { [key: string]: { name: string; description: string; image: string; images?: string[]; technologies: { name: string; color: string; icon: string }[] } } = t.projectsData;
     
     return (
-        <div id="experience" className="flex flex-col items-center justify-center w-full h-auto p-6 md:p-12 space-y-8 font-halcyon text-white bg-transparent rounded-lg">
+        <div id="projects" className="flex flex-col items-center justify-center w-full h-auto p-6 md:p-12 space-y-8 font-halcyon text-white bg-transparent rounded-lg">
             {/* Header */}
             <div className="text-4xl md:text-6xl text-[#FFFFE3] font-bold font-Interphases text-center w-full md:w-2/3 lg:w-1/2">
                 {t.projects}


### PR DESCRIPTION
## Summary
- assign unique IDs to `ProjectsHome` and `MyStack`
- keep `HeroSection` scroll behaviour to `#experience`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_68408f688e088321bd51a231b52d0d55